### PR TITLE
changed Future<Null> to Future<void>

### DIFF
--- a/example/lib/days_page_view_example.dart
+++ b/example/lib/days_page_view_example.dart
@@ -191,7 +191,7 @@ class _DaysPageControllerInitialisationDialogState
     _daysPerPage = DateTime.daysPerWeek;
   }
 
-  Future<Null> _changeFirstDayOfInitialPage() async {
+  Future<void> _changeFirstDayOfInitialPage() async {
     DateTime newFirstDayOfInitialPage = await showDatePicker(
       context: context,
       initialDate: _firstDayOfInitialPage,

--- a/lib/src/calendar_page_view/calendar_page_controller.dart
+++ b/lib/src/calendar_page_view/calendar_page_controller.dart
@@ -43,7 +43,7 @@ abstract class CalendarPageController {
   /// Works similar as [PageController.animateToPage].
   ///
   /// If nothing is attached to this controller it throws an exception.
-  Future<Null> animateToPage(
+  Future<void> animateToPage(
     int page, {
     @required Duration duration,
     @required Curve curve,

--- a/lib/src/calendar_page_view/calendar_page_link.dart
+++ b/lib/src/calendar_page_view/calendar_page_link.dart
@@ -16,7 +16,7 @@ typedef void JumpToPageCallback(
 /// Signature for a function that animates [CalendarPageView] to the given page.
 ///
 /// Works similar as [PageController.animateToPage].
-typedef Future<Null> AnimateToPageCallback(
+typedef Future<void> AnimateToPageCallback(
   int page, {
   @required Duration duration,
   @required Curve curve,

--- a/lib/src/calendar_page_view/calendar_page_view.dart
+++ b/lib/src/calendar_page_view/calendar_page_view.dart
@@ -73,7 +73,7 @@ abstract class CalendarPageViewState<WIDGET extends CalendarPageView>
 
   /// Animates to the given page.
   @protected
-  Future<Null> animateToPage(
+  Future<void> animateToPage(
     int page, {
     @required Duration duration,
     @required Curve curve,

--- a/lib/src/days_page_view/days_page_controller.dart
+++ b/lib/src/days_page_view/days_page_controller.dart
@@ -70,7 +70,7 @@ class DaysPageController extends CalendarPageController {
   /// Works similar as [PageController.animateToPage].
   ///
   /// If nothing is attached to this controller it throws an exception.
-  Future<Null> animateToDay(
+  Future<void> animateToDay(
     DateTime day, {
     @required Duration duration,
     @required Curve curve,

--- a/lib/src/days_page_view/days_page_link.dart
+++ b/lib/src/days_page_view/days_page_link.dart
@@ -18,7 +18,7 @@ typedef void JumpToDayCallback(
 /// Signature for a function that animates [DaysPageView] to the given day.
 ///
 /// Works similar as [PageController.animateToPage].
-typedef Future<Null> AnimateToDayCallback(
+typedef Future<void> AnimateToDayCallback(
   DateTime day, {
   @required Duration duration,
   @required Curve curve,

--- a/lib/src/days_page_view/days_page_view.dart
+++ b/lib/src/days_page_view/days_page_view.dart
@@ -108,7 +108,7 @@ class _DaysPageViewState extends CalendarPageViewState<DaysPageView> {
     jumpToPage(page);
   }
 
-  Future<Null> _animateToDay(
+  Future<void> _animateToDay(
     DateTime day, {
     @required Duration duration,
     @required Curve curve,

--- a/lib/src/month_page_view/month_page_controller.dart
+++ b/lib/src/month_page_view/month_page_controller.dart
@@ -65,7 +65,7 @@ class MonthPageController extends CalendarPageController {
   /// Works similar as [PageController.animateToPage].
   ///
   /// If nothing is attached to this controller it throws an exception.
-  Future<Null> animateToMonth(
+  Future<void> animateToMonth(
     DateTime month, {
     @required Duration duration,
     @required Curve curve,

--- a/lib/src/month_page_view/month_page_link.dart
+++ b/lib/src/month_page_view/month_page_link.dart
@@ -18,7 +18,7 @@ typedef void JumpToMonthCallback(
 /// Signature for a function that animates [MonthPageView] to the given month.
 ///
 /// Works similar as [PageController.animateToPage].
-typedef Future<Null> AnimateToMonthCallback(
+typedef Future<void> AnimateToMonthCallback(
   DateTime month, {
   @required Duration duration,
   @required Curve curve,

--- a/lib/src/month_page_view/month_page_view.dart
+++ b/lib/src/month_page_view/month_page_view.dart
@@ -105,7 +105,7 @@ class _MonthPageViewState extends CalendarPageViewState<MonthPageView> {
     jumpToPage(page);
   }
 
-  Future<Null> _animateToMonth(
+  Future<void> _animateToMonth(
     DateTime month, {
     @required Duration duration,
     @required Curve curve,


### PR DESCRIPTION
fixes for example:
```dart
The following assertion was thrown while handling a gesture:
I/flutter ( 3695): type 'Future<void>' is not a subtype of type 'Future<Null>'
I/flutter ( 3695): 
I/flutter ( 3695): Either the assertion indicates an error in the framework itself, or we should provide substantially
I/flutter ( 3695): more information in this error message to help you determine and fix the underlying cause.
I/flutter ( 3695): In either case, please report this assertion by filing a bug on GitHub:
I/flutter ( 3695):   https://github.com/flutter/flutter/issues/new?template=BUG.md
I/flutter ( 3695): 
I/flutter ( 3695): When the exception was thrown, this was the stack:
I/flutter ( 3695): #0      CalendarPageViewState.animateToPage (package:calendar_views/src/calendar_page_view/calendar_page_view.dart:81:5)
I/flutter ( 3695): #1      _MonthPageViewState._animateToMonth (package:calendar_views/src/month_page_view/month_page_view.dart:116:12)
I/flutter ( 3695): #2      MonthPageController.animateToMonth (package:calendar_views/src/month_page_view/month_page_controller.dart:75:25)
I/flutter ( 3695): #3      _CalendarWidgetState._getMonthWidget.<anonymous closure>.<anonymous closure> (package:schoolsen_mobile/widgets/calendar_widget.dart:300:40)
I/flutter ( 3695): #4      State.setState (package:flutter/src/widgets/framework.dart:1130:30)
I/flutter ( 3695): #5      _CalendarWidgetState._getMonthWidget.<anonymous closure> (package:schoolsen_mobile/widgets/calendar_widget.dart:298:15)
I/flutter ( 3695): #6      _InkResponseState._handleTap (package:flutter/src/material/ink_well.dart:507:14)
I/flutter ( 3695): #7      _InkResponseState.build.<anonymous closure> (package:flutter/src/material/ink_well.dart:562:30)
I/flutter ( 3695): #8      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:102:24)
I/flutter ( 3695): #9      TapGestureRecognizer._checkUp (package:flutter/src/gestures/tap.dart:242:9)
I/flutter ( 3695): #10     TapGestureRecognizer.acceptGesture (package:flutter/src/gestures/tap.dart:204:7)
I/flutter ( 3695): #11     GestureArenaManager.sweep (package:flutter/src/gestures/arena.dart:156:27)
I/flutter ( 3695): #12     _WidgetsFlutterBinding&BindingBase&GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:184:20)
I/flutter ( 3695): #13     _WidgetsFlutterBinding&BindingBase&GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:158:22)
I/flutter ( 3695): #14     _WidgetsFlutterBinding&BindingBase&GestureBinding._handlePointerEvent (package:flutter/src/gestures/binding.dart:138:7)
I/flutter ( 3695): #15     _WidgetsFlutterBinding&BindingBase&GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:101:7)
I/flutter ( 3695): #16     _WidgetsFlutterBinding&BindingBase&GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:85:7)
I/flutter ( 3695): #20     _invoke1 (dart:ui/hooks.dart:170:10)
I/flutter ( 3695): #21     _dispatchPointerDataPacket (dart:ui/hooks.dart:122:5)
I/flutter ( 3695): (elided 3 frames from package dart:async)
I/flutter ( 3695): 
I/flutter ( 3695): Handler: onTap
I/flutter ( 3695): Recognizer:
I/flutter ( 3695):   TapGestureRecognizer#30b86(debugOwner: GestureDetector, state: ready, won arena, finalPosition:
I/flutter ( 3695):   Offset(363.7, 117.4), sent tap down)
```