### PR TITLE
Updated issue with Flutter

### DIFF
--- a/lib/src/day_view/day_view_essentials/day_view_essentials.dart
+++ b/lib/src/day_view/day_view_essentials/day_view_essentials.dart
@@ -90,6 +90,6 @@ class _DayViewEssentialsInherited extends InheritedWidget {
   }
 
   static _DayViewEssentialsInherited of(BuildContext context) {
-    return context.inheritFromWidgetOfExactType(_DayViewEssentialsInherited);
+    return context.dependOnInheritedWidgetOfExactType();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.1.5
-  quiver: ^2.0.0+1
+  quiver: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Renamed inheritFromWidgetOfExactType to dependOnInheritedWidgetOfExactType

I don't know if you've had this issue, but it helped me to continue to use this package, so thought I'd share it. Thanks for an awesome package BTW! 